### PR TITLE
Fail the response future when the async executor rejects a task

### DIFF
--- a/client/src/main/java/dev/resteasy/jetty/client/engine/JettyClientEngine.java
+++ b/client/src/main/java/dev/resteasy/jetty/client/engine/JettyClientEngine.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -165,18 +166,22 @@ public class JettyClientEngine implements AsyncClientHttpEngine {
         if (entity != null) {
             final OutputStreamRequestContent contentOut = new OutputStreamRequestContent(
                     Objects.toString(invocation.getHeaders().getMediaType(), null));
-            asyncExecutor.execute(() -> {
-                try {
-                    try (OutputStream bodyOut = contentOut.getOutputStream()) {
-                        invocation.writeRequestBody(bodyOut);
+            // A rejection here (executor shut down before the body task is queued) escapes on the
+            // calling thread, leaving the future uncompleted; fail it explicitly instead.
+            try {
+                asyncExecutor.execute(() -> {
+                    try {
+                        try (OutputStream bodyOut = contentOut.getOutputStream()) {
+                            invocation.writeRequestBody(bodyOut);
+                        }
+                    } catch (Exception e) { // Also catch any exception thrown from close
+                        failFuture(future, callback, clientException(e, null));
                     }
-                } catch (Exception e) { // Also catch any exception thrown from close
-                    future.completeExceptionally(e);
-                    if (callback != null) {
-                        callback.failed(e);
-                    }
-                }
-            });
+                });
+            } catch (RejectedExecutionException e) {
+                failFuture(future, callback, clientException(e, null));
+                return future;
+            }
             request.body(contentOut);
         }
 
@@ -192,41 +197,35 @@ public class JettyClientEngine implements AsyncClientHttpEngine {
                 cr.setProperties(invocation.getMutableProperties());
                 cr.setStatus(response.getStatus());
                 cr.setHeaders(extract(response.getHeaders()));
-                asyncExecutor.submit(() -> {
-                    try {
-                        if (buffered) {
-                            cr.bufferEntity();
-                        }
-                        complete(extractor == null ? (T) cr : extractor.extractResult(cr));
-                    } catch (Exception e) {
+                try {
+                    asyncExecutor.submit(() -> {
                         try {
-                            inputStream.close();
-                        } catch (Exception e1) {
-                            e.addSuppressed(e1);
+                            if (buffered) {
+                                cr.bufferEntity();
+                            }
+                            complete(extractor == null ? (T) cr : extractor.extractResult(cr));
+                        } catch (Exception e) {
+                            onFailure(response, closeSuppressing(inputStream, e));
                         }
-                        onFailure(response, e);
-                    }
-                });
+                    });
+                } catch (RejectedExecutionException e) {
+                    // The executor was shut down (e.g. the client was closed) before the completion
+                    // task could be queued. Jetty considers the exchange successful and would swallow
+                    // this exception, leaving the future forever incomplete; fail it explicitly instead.
+                    onFailure(response, closeSuppressing(inputStream, e));
+                }
             }
 
             @Override
             public void onFailure(Response response, Throwable failure) {
                 super.onFailure(response, failure);
-                failed(failure);
+                failFuture(future, callback, clientException(failure, cr));
             }
 
             private void complete(T result) {
                 future.complete(result);
                 if (callback != null) {
                     callback.completed(result);
-                }
-            }
-
-            private void failed(Throwable t) {
-                final RuntimeException x = clientException(t, cr);
-                future.completeExceptionally(x);
-                if (callback != null) {
-                    callback.failed(x);
                 }
             }
         });
@@ -274,6 +273,29 @@ public class JettyClientEngine implements AsyncClientHttpEngine {
         final MultivaluedMap<String, String> extracted = new MultivaluedHashMap<>();
         headers.forEach(h -> extracted.add(h.getName(), h.getValue()));
         return extracted;
+    }
+
+    private static <T> void failFuture(CompletableFuture<T> future, InvocationCallback<T> callback, RuntimeException x) {
+        future.completeExceptionally(x);
+        if (callback != null) {
+            callback.failed(x);
+        }
+    }
+
+    /**
+     * Closes {@code closeable} if non-null, recording any failure as a suppressed exception on
+     * {@code primary}, and returns {@code primary} so it can be passed straight to a failure
+     * handler without losing the original cause.
+     */
+    private static Throwable closeSuppressing(AutoCloseable closeable, Throwable primary) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                primary.addSuppressed(e);
+            }
+        }
+        return primary;
     }
 
     private static RuntimeException clientException(Throwable ex, jakarta.ws.rs.core.Response clientResponse) {

--- a/client/src/test/java/dev/resteasy/jetty/client/JettyClientEngineTest.java
+++ b/client/src/test/java/dev/resteasy/jetty/client/JettyClientEngineTest.java
@@ -2,6 +2,8 @@ package dev.resteasy.jetty.client;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -11,11 +13,17 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
@@ -32,6 +40,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
 import org.apache.http.entity.ContentType;
+import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.io.Content;
@@ -41,6 +50,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -270,6 +280,168 @@ public class JettyClientEngineTest {
         assertEquals(200, response.getStatus());
         assertEquals("Success", response.readEntity(String.class));
 
+    }
+
+    /**
+     * If the async executor is shut down while a request is in flight, the completion task
+     * submitted from {@code onHeaders} is rejected. Jetty treats the exchange as successful and
+     * swallows that {@link java.util.concurrent.RejectedExecutionException}, so the response
+     * future was previously left forever incomplete and the synchronous caller hung on the
+     * engine's one-hour {@code future.get}. The engine must instead fail the future, so the call
+     * returns promptly with an error.
+     */
+    @Test
+    public void testExecutorShutdownWhileInFlightDoesNotHang() throws Exception {
+        final ExecutorService delegate = Executors.newSingleThreadExecutor();
+        final RejectionRecordingExecutor executor = new RejectionRecordingExecutor(delegate);
+
+        // The handler shuts the executor down *before* writing any response bytes. Because this
+        // runs only after the request has been fully sent and received, the sole remaining executor
+        // interaction is the onHeaders completion submit on the client side, which is therefore
+        // guaranteed to be rejected -- no race, and the pre-send body path (GET has no entity) is
+        // never involved.
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final org.eclipse.jetty.server.Response response,
+                    final Callback callback) throws Exception {
+                executor.shutdownNow();
+                response.setStatus(200);
+                Content.Sink.write(response, true, "Success", callback);
+                return true;
+            }
+        });
+        if (!server.isStarted()) {
+            server.start();
+        }
+        client = clientWithExecutor(executor);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(15),
+                () -> assertThrows(ProcessingException.class, () -> client.target(baseUri()).request().get(String.class)),
+                "synchronous call must fail fast, not hang on the engine's one-hour future.get");
+        // Prove the failure was produced by the guarded reject-at-onHeaders path, not some other
+        // fast failure, so the test cannot pass for the wrong reason.
+        assertTrue(executor.rejectedAfterShutdown(),
+                "expected the onHeaders completion submit to be rejected by the shut-down executor");
+    }
+
+    /**
+     * The empty-body variant of {@link #testExecutorShutdownWhileInFlightDoesNotHang}: the response
+     * carries no entity, so there is never a body read that a request timeout or idle timeout could
+     * interrupt. The exchange completes cleanly from Jetty's point of view the instant the (empty)
+     * response arrives, so the swallowed rejection can only be caught by the engine's own guard --
+     * no timeout can rescue this shape. The call must still fail fast rather than hang.
+     */
+    @Test
+    public void testExecutorShutdownWithEmptyBodyDoesNotHang() throws Exception {
+        final ExecutorService delegate = Executors.newSingleThreadExecutor();
+        final RejectionRecordingExecutor executor = new RejectionRecordingExecutor(delegate);
+
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final org.eclipse.jetty.server.Response response,
+                    final Callback callback) throws Exception {
+                executor.shutdownNow();
+                // 204 with no content: the response has no entity body at all.
+                response.setStatus(204);
+                callback.succeeded();
+                return true;
+            }
+        });
+        if (!server.isStarted()) {
+            server.start();
+        }
+        client = clientWithExecutor(executor);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(15),
+                () -> assertThrows(ProcessingException.class, () -> client.target(baseUri()).request().get()),
+                "empty-body call must fail fast; no timeout can rescue a body-less response");
+        assertTrue(executor.rejectedAfterShutdown(),
+                "expected the onHeaders completion submit to be rejected by the shut-down executor");
+    }
+
+    /**
+     * A request with an entity hands the body-writing task to the async executor before the request
+     * is sent. If that executor is already shut down, the submission is rejected on the calling
+     * thread; the engine must translate that into a {@link ProcessingException} and complete the
+     * future exceptionally rather than letting a raw {@code RejectedExecutionException} escape and
+     * leaving the future dangling.
+     */
+    @Test
+    public void testEntityRequestFailsFastWhenExecutorShutDown() throws Exception {
+        server.setHandler(new EchoHandler());
+        if (!server.isStarted()) {
+            server.start();
+        }
+
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.shutdownNow();
+        client = clientWithExecutor(executor);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(15), () -> assertThrows(ProcessingException.class,
+                () -> client.target(baseUri()).request()
+                        .post(Entity.entity("body", MediaType.TEXT_PLAIN_TYPE), String.class)));
+    }
+
+    private static ResteasyClient clientWithExecutor(final ExecutorService executor) {
+        return (ResteasyClient) new ResteasyClientBuilderImpl()
+                .executorService(executor)
+                .httpEngine(new JettyClientEngine(new HttpClient(), 0, TimeUnit.MILLISECONDS))
+                .build();
+    }
+
+    /**
+     * Delegating {@link ExecutorService} that records whether any {@code submit}/{@code execute}
+     * was rejected after the executor had been shut down, so a test can assert it actually hit the
+     * rejection path rather than passing via some unrelated fast failure.
+     */
+    private static final class RejectionRecordingExecutor extends AbstractExecutorService {
+        private final ExecutorService delegate;
+        private final AtomicBoolean rejectedAfterShutdown = new AtomicBoolean();
+
+        RejectionRecordingExecutor(final ExecutorService delegate) {
+            this.delegate = delegate;
+        }
+
+        boolean rejectedAfterShutdown() {
+            return rejectedAfterShutdown.get();
+        }
+
+        @Override
+        public void execute(final Runnable command) {
+            try {
+                delegate.execute(command);
+            } catch (RejectedExecutionException e) {
+                if (delegate.isShutdown()) {
+                    rejectedAfterShutdown.set(true);
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public void shutdown() {
+            delegate.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return delegate.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return delegate.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+            return delegate.awaitTermination(timeout, unit);
+        }
     }
 
     @Test


### PR DESCRIPTION
We've been seeing intermittent hangs during shutdown of our integration testing suite. I think it's because we lose a callback when the asyncExecutor is shutdown. We're testing this fix out internally now.

Claude writes:

> The Jetty client engine completes the response future only from a task that onHeaders submits to the client's async executor. If that executor is shut down while a request is in flight (for example, client.close() racing an in-flight call), asyncExecutor.submit throws RejectedExecutionException. That exception escaped onHeaders into Jetty's ResponseListeners.notifyHeaders, which logs and swallows it; Jetty had already seen a clean response, so onFailure never fired and the future was left neither completed nor failed. A synchronous caller then parked on the engine's hardcoded future.get(1, TimeUnit.HOURS).
> 
> Guard both executor hand-offs so a rejection fails the future instead:
> - onHeaders: catch RejectedExecutionException from the completion submit and route it through onFailure.
> - The pre-send request-body path: catch RejectedExecutionException from execute(...), fail the future, and return early so a request that can never complete is not sent.
> 
> Extract two helpers, failFuture(...) and closeSuppressing(...), to keep the failure and stream-close handling consistent across the paths.
> 
> Behavior change: a rejection (or other failure) in the async body-write path is now wrapped in a ProcessingException via clientException(...), consistent with every other failure route, rather than surfacing the raw exception to async submit(...) callers.
> 
> Add two regression tests bounded by assertTimeoutPreemptively so a reintroduced hang fails fast. The in-flight test drives the onHeaders reject path deterministically (the server shuts the executor down before writing the response) and asserts via a recording executor that the rejection actually occurred, so it cannot pass on the timeout alone.
```